### PR TITLE
[bugfix] Fix the labels of kappa-agg

### DIFF
--- a/kappa-agg.yml
+++ b/kappa-agg.yml
@@ -7,11 +7,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: kappa
+      app: kappa-agg
   template:
     metadata:
       labels:
-        app: kappa
+        app: kappa-agg
     spec:
       containers:
         - name: kappa
@@ -62,7 +62,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: kappa
+    app: kappa-agg
   ports:
     - name: agg
       protocol: TCP


### PR DESCRIPTION
Formerly, the service has been being attached to all kappa agents as well so that kappa agent could not send data to the aggregator properly. Now I fix the labels of kappa-agg in order to make `Service` is linked only to the kappa-agg.